### PR TITLE
Remove log server dependency from sample script

### DIFF
--- a/src/validation-verification-script/validation-verification-client.js
+++ b/src/validation-verification-script/validation-verification-client.js
@@ -35,24 +35,12 @@ class ValidationVerificationClient {
     }
 
     /**
-     * Log message to the server
-     * Message will have the format: <Date> :: <Message>
-     * For example: 10/8/2017, 10:41:11 AM::"OmidSupported[true]"
+     * Log message to the console.
      * @param {Object|string} message to send to the server
      * @param {number} timestamp of the event
      */
     logMessage_(message, timestamp) {
-        const log = (new Date(timestamp)).toLocaleString()+ '::' + JSON.stringify(message);
-        this.sendUrl_(log);
-    }
-
-    /**
-     * Call verificationClient sendUrl for message with the correct logServer
-     * @param {string} message to send to the server
-     */
-    sendUrl_(message) {
-        const url = (DefaultLogServer + encodeURIComponent(message));
-        this.verificationClient_.sendUrl(url);
+        console.log('[' + new Date(timestamp).toISOString() + ']', message);
     }
 
     /**


### PR DESCRIPTION
I ran into trouble with the `JSON.stringify()` call involved in formatting a message for the log server.

The reason is that `logMessage_()` is being called with objects that are potentially not serializable. Notably, on `sessionStart`, there's a data object containing the slot and video slot, so that throws because of circular references.

While there are npm packages that try achieve safe JSON serialization, fundamentally, I don't understand why a sample script relies on a logging server that doesn't exist. I guess this was introduced during development in an environment where the server does exist?

I'd like to suggest changing the logging calls to just use the console. That way, we can also just leverage the console's object view instead of attempting to serialize the object ourselves.