### PR TITLE
add missing percentageInView property to AdView object

### DIFF
--- a/src/common/event-typedefs.js
+++ b/src/common/event-typedefs.js
@@ -324,6 +324,7 @@ let EventData;
 /**
  * Provides information about the ad container geometry.
   * @typedef {{
+  *   percentageInView: number,
   *   geometry: !Geometry,
   *   onScreenGeometry: !OnScreenGeometry,
   *   reasons: !Array<!constants.Reason>,

--- a/src/common/logger.js
+++ b/src/common/logger.js
@@ -8,7 +8,7 @@ function error(...args) {
   executeLog(
       () => {
         // If this is a Jasmine run, throw loudly. Causing the tests to barf.
-        throw new Error('Could not complete the test successfully - ', ...args);
+        throw Error.apply(null, ['Could not complete the test successfully - ', ...args]);
       },
       () => console.error(...args)
   );


### PR DESCRIPTION
The OMID JS spec describes a `percentageInView` property attached to the AdView data object, this PR add this.