### PR TITLE
Add `@externs` annotation to externs files.

### DIFF
--- a/src/externs/omid-exports.js
+++ b/src/externs/omid-exports.js
@@ -1,2 +1,4 @@
+/** @externs */
+
 /** @type {!Object} */
 let omidExports;

--- a/src/externs/omid-global.js
+++ b/src/externs/omid-global.js
@@ -1,3 +1,5 @@
+/** @externs */
+
 /**
  * @type {!Window}
  */

--- a/src/externs/omid-jasmine.js
+++ b/src/externs/omid-jasmine.js
@@ -1,3 +1,5 @@
+/** @externs */
+
 /**
  * This represents the value of the jasmine variable in production runs of the
  * code. In production, this variable is checked by logger.js. If the variable

--- a/src/externs/omid-js-session-interface.js
+++ b/src/externs/omid-js-session-interface.js
@@ -1,3 +1,5 @@
+/** @externs */
+
 /**
  * @fileoverview @externs Definition of omidSessionInterface, used for session
  * client integration with the OM SDK service script.


### PR DESCRIPTION
Inside Google, we are enforcing the existence of this annotation on all
externs files, which helps prevent their misuse as non-externs.