### PR TITLE
Add DoubleVerify partner hosted scripts

### DIFF
--- a/src/session-client/verification-vendor.js
+++ b/src/session-client/verification-vendor.js
@@ -52,6 +52,8 @@ const VERIFICATION_VENDORS = new Map([
     VerificationVendorId.DOUBLEVERIFY,
     [
       /^(https?:\/\/|\/\/)?[-a-zA-Z0-9.]+\.doubleverify\.com\/.*$/,
+      /^(https?:\/\/|\/\/)?c\.amazon\-adsystem\.com\/vfw\/dv\/.*$/,
+      /^(https?:\/\/|\/\/)?www\.twitch\.tv\/r\/s\/d\/.*$/,
     ],
   ],
   [

--- a/test/unit/session-client/verification-vendor-test.js
+++ b/test/unit/session-client/verification-vendor-test.js
@@ -11,6 +11,12 @@ describe('verificationVendorIdForScriptUrl', () => {
     expectScriptUrlToMatchVendorId(
         'https://cdn.doubleverify.com/script.js',
         VerificationVendorId.DOUBLEVERIFY);
+    expectScriptUrlToMatchVendorId(
+        'https://c.amazon-adsystem.com/vfw/dv/script.js',
+        VerificationVendorId.DOUBLEVERIFY);
+    expectScriptUrlToMatchVendorId(
+        'https://www.twitch.tv/r/s/d/script.js',
+        VerificationVendorId.DOUBLEVERIFY);
   });
   it('correctly identifies IAS URLs', () => {
     expectScriptUrlToMatchVendorId(


### PR DESCRIPTION
This pull request adds two additional URL structures for scripts published and maintained by DoubleVerify but hosted on partner CDNs.