### PR TITLE
added Mobian as a verification vendor

### DIFF
--- a/src/session-client/verification-vendor.js
+++ b/src/session-client/verification-vendor.js
@@ -18,6 +18,7 @@ const VerificationVendorId = {
   MEETRICS: 8,
   GOOGLE: 9,
   HUMAN: 10,
+  MOBIAN: 11,
 };
 
 /**
@@ -100,6 +101,12 @@ const VERIFICATION_VENDORS = new Map([
       /^(https?:\/\/|\/\/)?[-a-zA-Z0-9.]+\/(2|ag|static)\/[a-zA-Z0-9.]*\/analytics.js.*$/,
     ],
   ],
+  [
+    VerificationVendorId.MOBIAN,
+    [
+      /^(https?:\/\/|\/\/)?[-a-zA-Z0-9.]+\.outcomes\.net\/.*$/,
+    ],
+  ],  
 ]);
 
 packageExport(

--- a/test/unit/session-client/verification-vendor-test.js
+++ b/test/unit/session-client/verification-vendor-test.js
@@ -65,6 +65,11 @@ describe('verificationVendorIdForScriptUrl', () => {
         'https://ads.example.com/static/1.2.3/analytics.js?',
         VerificationVendorId.HUMAN);
   });
+  it('correctly identifies Mobian URLs', () => {
+    expectScriptUrlToMatchVendorId(
+        'https://js.outcomes.net/script.js',
+        VerificationVendorId.MOBIAN);
+  });
   it('returns OTHER for unrecognized URLs', () => {
     expectScriptUrlToMatchVendorId(
         'https://cdn.some-other-vendor.com/vendor.js',


### PR DESCRIPTION
- Added Mobian as a Verififcation Vendor
- Included regression test

This allows clients to set vendor specific access levels: https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/reference/namespace/google.ima#google.ima.OmidVerificationVendor

